### PR TITLE
ci: use keyserver.ubuntu.com as a key-server

### DIFF
--- a/.github/workflows/check_all.yml
+++ b/.github/workflows/check_all.yml
@@ -39,7 +39,7 @@ jobs:
         continue-on-error: true
 
       - name: Refresh GPG keys
-        run: gpg --keyserver pool.sks-keyservers.net --refresh-keys
+        run: gpg --keyserver keyserver.ubuntu.com --refresh-keys
 
       # Check that gitian asserts don't conflict and that sigs validate
       - name: Run Test Script


### PR DESCRIPTION
Should fix failures like
```
Run gpg --keyserver pool.sks-keyservers.net --refresh-keys
  gpg --keyserver pool.sks-keyservers.net --refresh-keys
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.10.4/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.4/x64/lib
gpg: refreshing 9 keys from hkp://pool.sks-keyservers.net
gpg: keyserver refresh failed: Server indicated a failure
Error: Process completed with exit code 2.
```
https://github.com/dashpay/gitian.sigs/runs/6183594028?check_suite_focus=true#step:7:2

after the patch
```
Run gpg --keyserver keyserver.ubuntu.com --refresh-keys
  gpg --keyserver keyserver.ubuntu.com --refresh-keys
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.10.4/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.4/x64/lib
gpg: refreshing 9 keys from hkp://keyserver.ubuntu.com
gpg: key 8359[2](https://github.com/UdjinM6/gitian.sigs/runs/6184023788?check_suite_focus=true#step:7:2)BD1400D58D9: "UdjinM6 <UdjinM6@dash.org>" [3](https://github.com/UdjinM6/gitian.sigs/runs/6184023788?check_suite_focus=true#step:7:3) new user IDs
gpg: key 83592BD1[4](https://github.com/UdjinM6/gitian.sigs/runs/6184023788?check_suite_focus=true#step:7:4)00D[5](https://github.com/UdjinM6/gitian.sigs/runs/6184023788?check_suite_focus=true#step:7:5)8D9: "UdjinM[6](https://github.com/UdjinM6/gitian.sigs/runs/6184023788?check_suite_focus=true#step:7:6) <UdjinM6@dash.org>" 10 new signatures
gpg: key 631[7](https://github.com/UdjinM6/gitian.sigs/runs/6184023788?check_suite_focus=true#step:7:7)F01E6F491072: "thephez <thephez@gmail.com>" 1 new user ID
gpg: key 6317F01E6F491072: "thephez <thephez@gmail.com>" 1 new signature
gpg: key 4B[8](https://github.com/UdjinM6/gitian.sigs/runs/6184023788?check_suite_focus=true#step:7:8)826[9](https://github.com/UdjinM6/gitian.sigs/runs/6184023788?check_suite_focus=true#step:7:9)ABD8DF332: "Holger Schinzel <holger@dash.org>" 3 new signatures
gpg: key 52527BEDABE87984: "Pasta <pasta@dashboost.org>" 1 new user ID
gpg: key 52527BEDABE87984: "Pasta <pasta@dashboost.org>" 3 new signatures
gpg: key AAE1CD6BA06E985C: "Nathan Marley <nathan.marley@gmail.com>" not changed
gpg: key 34E451CAD75746B8: "gladcow <sergey@dash.org>" not changed
gpg: key 63A96B406[10](https://github.com/UdjinM6/gitian.sigs/runs/6184023788?check_suite_focus=true#step:7:10)2E091: "Alexander Block (codablock) <alexander.block@dash.org>" 1 new user ID
gpg: key 63A96B406102E091: "Alexander Block (codablock) <alexander.block@dash.org>" 1 new signature
gpg: Total number processed: 7
gpg:              unchanged: 2
gpg:           new user IDs: 6
gpg:         new signatures: [18]
```
https://github.com/UdjinM6/gitian.sigs/runs/6184023788?check_suite_focus=true#step:7:1